### PR TITLE
fix: Reference correct setting names for `lat`/`lon` params

### DIFF
--- a/tap_openweathermap/streams.py
+++ b/tap_openweathermap/streams.py
@@ -57,8 +57,8 @@ class WeatherStream(_SyncedAtStream):
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         params = super().get_url_params(context, next_page_token)
-        params["lat"] = self.config.get("weather_lattitude")
-        params["lon"] = self.config.get("weather_longitude")
+        params["lat"] = self.config.get("forecast_weather_lattitude")
+        params["lon"] = self.config.get("forecast_weather_longitude")
         params["appid"] = self.config.get("api_key")
 
         return params

--- a/tap_openweathermap/streams.py
+++ b/tap_openweathermap/streams.py
@@ -57,8 +57,8 @@ class WeatherStream(_SyncedAtStream):
         self, context: Optional[dict], next_page_token: Optional[Any]
     ) -> Dict[str, Any]:
         params = super().get_url_params(context, next_page_token)
-        params["lat"] = self.config.get("forecast_weather_lattitude")
-        params["lon"] = self.config.get("forecast_weather_longitude")
-        params["appid"] = self.config.get("api_key")
+        params["lat"] = self.config["forecast_weather_lattitude"]
+        params["lon"] = self.config["forecast_weather_longitude"]
+        params["appid"] = self.config["api_key"]
 
         return params


### PR DESCRIPTION
Hello,

It's a look to the [pull request #5](https://github.com/Matatika/tap-openweathermap/pull/5) from another side.

Thank you for the prompt replies,
Dm.